### PR TITLE
Add X-Grvt-Account-Id token to Rest API and WebSocket connections.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grvt-pysdk"
-version = "0.1.14"
+version = "0.1.15"
 description = "GRVT Python SDK"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }

--- a/src/pysdk/grvt_ccxt.py
+++ b/src/pysdk/grvt_ccxt.py
@@ -55,12 +55,8 @@ class GrvtCcxt(GrvtCcxtBase):
         """Initialize the GrvtCcxt instance."""
         super().__init__(env, logger, parameters)
         self._clsname: str = type(self).__name__
-        self._session = requests.Session()
-        self._session.headers.update(
-            {
-                "Content-Type": "application/json",
-            }
-        )
+        self._session: requests.Session = requests.Session()
+        self._session.headers.update({"Content-Type": "application/json"})
         self.refresh_cookie()
         # Assign markets here
         self.markets = self.load_markets()
@@ -74,7 +70,9 @@ class GrvtCcxt(GrvtCcxtBase):
         self._path_return_value_map[path] = self._cookie
         if self._cookie:
             self._session.cookies.update({"gravity": self._cookie["gravity"]})
-            self._session.headers.update({"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]})
+            self._session.headers.update(
+                {"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]}
+            )
             self.logger.info(
                 f"refresh_cookie {self._cookie=} {self._session.cookies=}"
                 f" {self._session.headers=}"

--- a/src/pysdk/grvt_ccxt.py
+++ b/src/pysdk/grvt_ccxt.py
@@ -70,9 +70,10 @@ class GrvtCcxt(GrvtCcxtBase):
         self._path_return_value_map[path] = self._cookie
         if self._cookie:
             self._session.cookies.update({"gravity": self._cookie["gravity"]})
-            self._session.headers.update(
-                {"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]}
-            )
+            if self._cookie["X-Grvt-Account-Id"]:
+                self._session.headers.update(
+                    {"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]}
+                )
             self.logger.info(
                 f"refresh_cookie {self._cookie=} {self._session.cookies=}"
                 f" {self._session.headers=}"

--- a/src/pysdk/grvt_ccxt.py
+++ b/src/pysdk/grvt_ccxt.py
@@ -61,8 +61,6 @@ class GrvtCcxt(GrvtCcxtBase):
                 "Content-Type": "application/json",
             }
         )
-
-        # self._cookie: dict | None = None
         self.refresh_cookie()
         # Assign markets here
         self.markets = self.load_markets()
@@ -75,8 +73,12 @@ class GrvtCcxt(GrvtCcxtBase):
         self._cookie = get_cookie_with_expiration(path, self._api_key)
         self._path_return_value_map[path] = self._cookie
         if self._cookie:
-            self.logger.info(f"refresh_cookie cookie={self._cookie}")
             self._session.cookies.update({"gravity": self._cookie["gravity"]})
+            self._session.headers.update({"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]})
+            self.logger.info(
+                f"refresh_cookie {self._cookie=} {self._session.cookies=}"
+                f" {self._session.headers=}"
+            )
         return self._cookie
 
     # PRIVATE API CALLS

--- a/src/pysdk/grvt_ccxt_pro.py
+++ b/src/pysdk/grvt_ccxt_pro.py
@@ -68,7 +68,10 @@ class GrvtCcxtPro(GrvtCcxtBase):
         if self._cookie:
             self.logger.info(f"refresh_cookie cookie={self._cookie}")
             self._session.cookie_jar.update_cookies({"gravity": self._cookie["gravity"]})
-            self._session.headers.update({"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]})
+            if self._cookie["X-Grvt-Account-Id"]:
+                self._session.headers.update(
+                    {"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]}
+                )
             self.logger.info(
                 f"refresh_cookie {self._cookie=} {self._session.cookie_jar=}"
                 f" {self._session.headers=}"
@@ -84,7 +87,9 @@ class GrvtCcxtPro(GrvtCcxtBase):
         if self._cookie:
             self.logger.info(f"refresh_cookie cookie={self._cookie}")
             self._session.cookie_jar.update_cookies({"gravity": self._cookie["gravity"]})
-            self._session.headers.update({"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]})
+            self._session.headers.update(
+                {"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]}
+            )
             self.logger.info(
                 f"refresh_cookie {self._cookie=} {self._session.cookie_jar=}"
                 f" {self._session.headers=}"

--- a/src/pysdk/grvt_ccxt_pro.py
+++ b/src/pysdk/grvt_ccxt_pro.py
@@ -61,12 +61,18 @@ class GrvtCcxtPro(GrvtCcxtBase):
         self._session = aiohttp.ClientSession(
             headers={"Content-Type": "application/json"}
         )
+        # Force sync call to get cookie here
         self._cookie = get_cookie_with_expiration(
             get_grvt_endpoint(self.env, "AUTH"), self._api_key
         )
         if self._cookie:
             self.logger.info(f"refresh_cookie cookie={self._cookie}")
             self._session.cookie_jar.update_cookies({"gravity": self._cookie["gravity"]})
+            self._session.headers.update({"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]})
+            self.logger.info(
+                f"refresh_cookie {self._cookie=} {self._session.cookie_jar=}"
+                f" {self._session.headers=}"
+            )
 
     async def refresh_cookie(self) -> dict | None:
         """Refresh the session cookie."""
@@ -78,6 +84,11 @@ class GrvtCcxtPro(GrvtCcxtBase):
         if self._cookie:
             self.logger.info(f"refresh_cookie cookie={self._cookie}")
             self._session.cookie_jar.update_cookies({"gravity": self._cookie["gravity"]})
+            self._session.headers.update({"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]})
+            self.logger.info(
+                f"refresh_cookie {self._cookie=} {self._session.cookie_jar=}"
+                f" {self._session.headers=}"
+            )
         return self._cookie
 
     # PRIVATE API CALLS

--- a/src/pysdk/grvt_ccxt_pro.py
+++ b/src/pysdk/grvt_ccxt_pro.py
@@ -65,15 +65,17 @@ class GrvtCcxtPro(GrvtCcxtBase):
         self._cookie = get_cookie_with_expiration(
             get_grvt_endpoint(self.env, "AUTH"), self._api_key
         )
+        self.update_session_with_cookie()
+
+    def update_session_with_cookie(self) -> None:
         if self._cookie:
-            self.logger.info(f"refresh_cookie cookie={self._cookie}")
             self._session.cookie_jar.update_cookies({"gravity": self._cookie["gravity"]})
             if self._cookie["X-Grvt-Account-Id"]:
                 self._session.headers.update(
                     {"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]}
                 )
             self.logger.info(
-                f"refresh_cookie {self._cookie=} {self._session.cookie_jar=}"
+                f"update_session_with_cookie {self._cookie=} {self._session.cookie_jar=}"
                 f" {self._session.headers=}"
             )
 
@@ -84,16 +86,7 @@ class GrvtCcxtPro(GrvtCcxtBase):
         path = get_grvt_endpoint(self.env, "AUTH")
         self._cookie = await get_cookie_with_expiration_async(path, self._api_key)
         self._path_return_value_map[path] = self._cookie
-        if self._cookie:
-            self.logger.info(f"refresh_cookie cookie={self._cookie}")
-            self._session.cookie_jar.update_cookies({"gravity": self._cookie["gravity"]})
-            self._session.headers.update(
-                {"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]}
-            )
-            self.logger.info(
-                f"refresh_cookie {self._cookie=} {self._session.cookie_jar=}"
-                f" {self._session.headers=}"
-            )
+        self.update_session_with_cookie()
         return self._cookie
 
     # PRIVATE API CALLS

--- a/src/pysdk/grvt_raw_base.py
+++ b/src/pysdk/grvt_raw_base.py
@@ -94,9 +94,10 @@ class GrvtRawSyncBase(GrvtRawBase):
         # Update cookie in session
         if self._cookie:
             self._session.cookies.update({"gravity": self._cookie.gravity})
-            self._session.headers.update(
-                {"X-Grvt-Account-Id": self._cookie.grvt_account_id}
-            )
+            if self._cookie.grvt_account_id:
+                self._session.headers.update(
+                    {"X-Grvt-Account-Id": self._cookie.grvt_account_id}
+                )
         return None
 
     def _get_cookie(self, path: str, api_key: str) -> GrvtCookie | None:
@@ -187,9 +188,10 @@ class GrvtRawAsyncBase(GrvtRawBase):
         # Update cookie in session
         if self._cookie:
             self._session.cookie_jar.update_cookies({"gravity": self._cookie.gravity})
-            self._session.headers.update(
-                {"X-Grvt-Account-Id": self._cookie.grvt_account_id}
-            )
+            if self._cookie.grvt_account_id:
+                self._session.headers.update(
+                    {"X-Grvt-Account-Id": self._cookie.grvt_account_id}
+                )
         return None
 
     async def _get_cookie(self, path: str, api_key: str) -> GrvtCookie | None:

--- a/tests/pysdk/test_grvt_ccxt_pro.py
+++ b/tests/pysdk/test_grvt_ccxt_pro.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import time
 import traceback
 
 from pysdk.grvt_ccxt_env import GrvtEnv

--- a/tests/pysdk/test_grvt_raw_sync.py
+++ b/tests/pysdk/test_grvt_raw_sync.py
@@ -66,7 +66,7 @@ def test_create_order_with_signing() -> None:
 def test_transfer_with_signing() -> None:
     api = GrvtRawSync(config=get_config())
     transfer = get_test_transfer(api)
-    
+
     if transfer is None:
         return None  # Skip test if configs are not set
 

--- a/uv.lock
+++ b/uv.lock
@@ -854,7 +854,7 @@ wheels = [
 
 [[package]]
 name = "grvt-pysdk"
-version = "0.1.14"
+version = "0.1.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp", marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },


### PR DESCRIPTION
Added X-Grvt-Account-Id for `row` and `ccxt` classes for Rest API and Web Socket connections.
Bumped version to 0.1.15