### PR TITLE
bump aiohttp>=3.10.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 readme = { file = "README.md", content-type = "text/markdown" }
 dependencies = [
-    "aiohttp>=3.10.5",
+    "aiohttp>=3.10.11",
     "backports-weakref>=1.0.post1",
     "dacite>=1.8.1",
     "dataclasses-json>=0.6.7",


### PR DESCRIPTION
Due to Medium level security alert on aiohttp 3.10.5 need to bump version to 3.10.11
See https://github.com/gravity-technologies/pytradebot/security/dependabot/1