### PR TITLE
Test transfer API calls

### DIFF
--- a/tests/pysdk/test_grvt_raw_sync.py
+++ b/tests/pysdk/test_grvt_raw_sync.py
@@ -2,7 +2,7 @@ from pysdk import grvt_raw_types
 from pysdk.grvt_raw_base import GrvtError
 from pysdk.grvt_raw_sync import GrvtRawSync
 
-from .test_raw_utils import get_config, get_test_order, get_test_transfer
+from test_raw_utils import get_config, get_test_order, get_test_transfer
 
 
 def test_get_all_instruments() -> None:

--- a/tests/pysdk/test_raw_utils.py
+++ b/tests/pysdk/test_raw_utils.py
@@ -76,7 +76,7 @@ def get_test_transfer(
     ):
         return None
 
-    private_key = keys.PrivateKey(bytes.fromhex(api.config.private_key))
+    private_key = keys.PrivateKey(str.encode(api.config.private_key))
     public_key = private_key.public_key
     funding_account_address = public_key.to_checksum_address()
 

--- a/tests/pysdk/test_transfer.py
+++ b/tests/pysdk/test_transfer.py
@@ -1,0 +1,4 @@
+from test_grvt_raw_sync import test_transfer_with_signing
+
+if __name__ == "__main__":
+    test_transfer_with_signing()


### PR DESCRIPTION
trying to run test 
```
% cd tests/pysdk
% python3 test_transfer.py
DEBUG:root:GrvtApiConfig(env=<GrvtEnv.TESTNET: 'testnet'>, trading_account_id='7191981255316734', private_key='0xc08dba5206ec2b4cfe2d11c64c03ee11bff833cb96099bbe25f5958b1d321ad2', api_key='2q4Xi6uyta8vslHCOCqv3T8jMtm', logger=<RootLogger root (DEBUG)>)
Traceback (most recent call last):
  File "/Users/evgenikhaimson/Development/grvt/grvt-pysdk/tests/pysdk/test_transfer.py", line 4, in <module>
    test_transfer_with_signing()
  File "/Users/evgenikhaimson/Development/grvt/grvt-pysdk/tests/pysdk/test_grvt_raw_sync.py", line 68, in test_transfer_with_signing
    transfer = get_test_transfer(api)
  File "/Users/evgenikhaimson/Development/grvt/grvt-pysdk/tests/pysdk/test_raw_utils.py", line 79, in get_test_transfer
    private_key = keys.PrivateKey(str.encode(api.config.private_key))
  File "/Users/evgenikhaimson/Development/grvt/grvt-pysdk/.venv.3.10/lib/python3.10/site-packages/eth_keys/datatypes.py", line 246, in __init__
    validate_private_key_bytes(private_key_bytes)
  File "/Users/evgenikhaimson/Development/grvt/grvt-pysdk/.venv.3.10/lib/python3.10/site-packages/eth_keys/validation.py", line 81, in validate_private_key_bytes
    validate_bytes_length(value, 32, "private key")
  File "/Users/evgenikhaimson/Development/grvt/grvt-pysdk/.venv.3.10/lib/python3.10/site-packages/eth_keys/validation.py", line 52, in validate_bytes_length
    raise ValidationError(
eth_utils.exceptions.ValidationError: Unexpected private key length: Expected 32, but got 66 bytes
```

with environment setup 
```
GRVT_API_KEY=<api key>
GRVT_PRIVATE_KEY=<private key>
GRVT_TRADING_ACCOUNT_ID=<account_id>
GRVT_ENV= `testnet | dev | staging`
GRVT_END_POINT_VERSION=v1
GRVT_WS_STREAM_VERSION=v1
GRVT_SUB_ACCOUNT_ID=<account_id>

```
