### PR TITLE
PySDK Refresh

### DIFF
--- a/src/pysdk/grvt_fixed_types.py
+++ b/src/pysdk/grvt_fixed_types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from .grvt_raw_types import Currency, Signature, TransferType
+from .grvt_raw_types import Signature, TransferType
 
 
 @dataclass
@@ -14,7 +14,7 @@ class Transfer:
     # The subaccount to transfer to (0 if transferring to main account)
     to_sub_account_id: str
     # The token currency to transfer
-    currency: Currency
+    currency: str
     # The number of tokens to transfer
     num_tokens: str
     # The signature of the transfer

--- a/src/pysdk/grvt_raw_async.py
+++ b/src/pysdk/grvt_raw_async.py
@@ -40,6 +40,14 @@ class GrvtRawAsync(GrvtRawAsyncBase):
             types.ApiGetFilteredInstrumentsResponse, resp, Config(cast=[Enum])
         )
 
+    async def get_currency_v1(
+        self, req: types.ApiGetCurrencyRequest
+    ) -> types.ApiGetCurrencyResponse | GrvtError:
+        resp = await self._post(False, self.md_rpc + "/full/v1/currency", req)
+        if resp.get("code"):
+            return GrvtError(**resp)
+        return from_dict(types.ApiGetCurrencyResponse, resp, Config(cast=[Enum]))
+
     async def mini_ticker_v1(
         self, req: types.ApiMiniTickerRequest
     ) -> types.ApiMiniTickerResponse | GrvtError:

--- a/src/pysdk/grvt_raw_async.py
+++ b/src/pysdk/grvt_raw_async.py
@@ -343,3 +343,15 @@ class GrvtRawAsync(GrvtRawAsyncBase):
         return from_dict(
             types.ApiVaultViewRedemptionQueueResponse, resp, Config(cast=[Enum])
         )
+
+    async def query_vault_manager_investor_history_v1(
+        self, req: types.ApiQueryVaultManagerInvestorHistoryRequest
+    ) -> types.ApiQueryVaultManagerInvestorHistoryResponse | GrvtError:
+        resp = await self._post(
+            True, self.td_rpc + "/full/v1/vault_manager_investor_history", req
+        )
+        if resp.get("code"):
+            return GrvtError(**resp)
+        return from_dict(
+            types.ApiQueryVaultManagerInvestorHistoryResponse, resp, Config(cast=[Enum])
+        )

--- a/src/pysdk/grvt_raw_signing.py
+++ b/src/pysdk/grvt_raw_signing.py
@@ -152,13 +152,13 @@ EIP712_TRANSFER_MESSAGE_TYPE = {
 }
 
 
-def build_EIP712_transfer_message_data(transfer: Transfer):
+def build_EIP712_transfer_message_data(transfer: Transfer, currencyId: int):
     return {
         "fromAccount": transfer.from_account_id,
         "fromSubAccount": transfer.from_sub_account_id,
         "toAccount": transfer.to_account_id,
         "toSubAccount": transfer.to_sub_account_id,
-        "tokenCurrency": GrvtCurrency[transfer.currency.value].value,
+        "tokenCurrency": currencyId,
         "numTokens": int(
             Decimal(transfer.num_tokens) * Decimal(1e6)
         ),  # USDT has 6 decimals
@@ -172,13 +172,14 @@ def sign_transfer(
     config: GrvtApiConfig,
     account: Account,
     chainId: int | None = None,
+    currencyId: int = 3,  # currencyId of USDT; refer to Get Currency API
 ) -> Transfer:
     if config.private_key is None:
         raise ValueError("Private key is not set")
 
     domain = get_EIP712_domain_data(config.env, chainId)
 
-    message_data = build_EIP712_transfer_message_data(transfer)
+    message_data = build_EIP712_transfer_message_data(transfer, currencyId)
     signable_message = encode_typed_data(
         domain, EIP712_TRANSFER_MESSAGE_TYPE, message_data
     )
@@ -208,11 +209,11 @@ EIP712_WITHDRAWAL_MESSAGE_TYPE = {
 }
 
 
-def build_EIP712_withdrawal_message_data(withdrawal: Withdrawal):
+def build_EIP712_withdrawal_message_data(withdrawal: Withdrawal, currencyId: int):
     return {
         "fromAccount": withdrawal.from_account_id,
         "toEthAddress": withdrawal.to_eth_address,
-        "tokenCurrency": GrvtCurrency[withdrawal.currency.value].value,
+        "tokenCurrency": currencyId,
         "numTokens": int(
             Decimal(withdrawal.num_tokens) * Decimal(1e6)
         ),  # USDT has 6 decimals
@@ -226,13 +227,14 @@ def sign_withdrawal(
     config: GrvtApiConfig,
     account: Account,
     chainId: int | None = None,
+    currencyId: int = 3,  # currencyId of USDT; refer to Get Currency API
 ) -> Withdrawal:
     if config.private_key is None:
         raise ValueError("Private key is not set")
 
     domain = get_EIP712_domain_data(config.env, chainId)
 
-    message_data = build_EIP712_withdrawal_message_data(withdrawal)
+    message_data = build_EIP712_withdrawal_message_data(withdrawal, currencyId)
     signable_message = encode_typed_data(
         domain, EIP712_WITHDRAWAL_MESSAGE_TYPE, message_data
     )

--- a/src/pysdk/grvt_raw_sync.py
+++ b/src/pysdk/grvt_raw_sync.py
@@ -329,3 +329,15 @@ class GrvtRawSync(GrvtRawSyncBase):
         return from_dict(
             types.ApiVaultViewRedemptionQueueResponse, resp, Config(cast=[Enum])
         )
+
+    def query_vault_manager_investor_history_v1(
+        self, req: types.ApiQueryVaultManagerInvestorHistoryRequest
+    ) -> types.ApiQueryVaultManagerInvestorHistoryResponse | GrvtError:
+        resp = self._post(
+            True, self.td_rpc + "/full/v1/vault_manager_investor_history", req
+        )
+        if resp.get("code"):
+            return GrvtError(**resp)
+        return from_dict(
+            types.ApiQueryVaultManagerInvestorHistoryResponse, resp, Config(cast=[Enum])
+        )

--- a/src/pysdk/grvt_raw_sync.py
+++ b/src/pysdk/grvt_raw_sync.py
@@ -40,6 +40,14 @@ class GrvtRawSync(GrvtRawSyncBase):
             types.ApiGetFilteredInstrumentsResponse, resp, Config(cast=[Enum])
         )
 
+    def get_currency_v1(
+        self, req: types.ApiGetCurrencyRequest
+    ) -> types.ApiGetCurrencyResponse | GrvtError:
+        resp = self._post(False, self.md_rpc + "/full/v1/currency", req)
+        if resp.get("code"):
+            return GrvtError(**resp)
+        return from_dict(types.ApiGetCurrencyResponse, resp, Config(cast=[Enum]))
+
     def mini_ticker_v1(
         self, req: types.ApiMiniTickerRequest
     ) -> types.ApiMiniTickerResponse | GrvtError:

--- a/src/pysdk/grvt_raw_types.py
+++ b/src/pysdk/grvt_raw_types.py
@@ -658,9 +658,20 @@ class FundingAccountSummary:
 
 
 @dataclass
+class ClientTier:
+    tier: int
+    futures_taker_fee: int
+    futures_maker_fee: int
+    options_taker_fee: int
+    options_maker_fee: int
+
+
+@dataclass
 class ApiFundingAccountSummaryResponse:
     # The funding account summary
     result: FundingAccountSummary
+    # Client fee tier at the time of query
+    tier: ClientTier
 
 
 @dataclass
@@ -1447,6 +1458,29 @@ class ApiGetFilteredInstrumentsRequest:
 class ApiGetFilteredInstrumentsResponse:
     # The instruments matching the request filter
     result: list[Instrument]
+
+
+@dataclass
+class ApiGetCurrencyRequest:
+    pass
+
+
+@dataclass
+class CurrencyDetail:
+    # The integer value of the currency
+    id: int
+    # The name of the currency
+    symbol: str
+    # The balance decimals of the currency
+    balance_decimals: int
+    # The quantity multiplier of the currency
+    quantity_multiplier: str
+
+
+@dataclass
+class ApiGetCurrencyResponse:
+    # The list of currencies
+    result: list[CurrencyDetail]
 
 
 @dataclass

--- a/tests/pysdk/test_grvt_raw_async.py
+++ b/tests/pysdk/test_grvt_raw_async.py
@@ -4,7 +4,12 @@ from pysdk import grvt_raw_types
 from pysdk.grvt_raw_async import GrvtRawAsync
 from pysdk.grvt_raw_base import GrvtError
 
-from .test_raw_utils import get_config, get_test_order, get_test_transfer, get_test_withdrawal
+from .test_raw_utils import (
+    get_config,
+    get_test_order,
+    get_test_transfer,
+    get_test_withdrawal,
+)
 
 
 async def get_all_instruments() -> None:
@@ -31,8 +36,8 @@ async def open_orders() -> None:
         grvt_raw_types.ApiOpenOrdersRequest(
             sub_account_id=str(api.config.trading_account_id),
             kind=[grvt_raw_types.Kind.PERPETUAL],
-            base=[grvt_raw_types.Currency.BTC, grvt_raw_types.Currency.ETH],
-            quote=[grvt_raw_types.Currency.USDT],
+            base=["BTC", "ETH"],
+            quote=["USDT"],
         )
     )
     if isinstance(resp, GrvtError):
@@ -67,7 +72,7 @@ async def create_order_with_signing() -> None:
 async def transfer_with_signing_async() -> None:
     api = GrvtRawAsync(config=get_config())
     transfer = get_test_transfer(api)
-    
+
     if transfer is None:
         return None  # Skip test if configs are not set
 
@@ -87,11 +92,12 @@ async def transfer_with_signing_async() -> None:
         raise ValueError(f"Received error: {resp}")
     if resp.result is None:
         raise ValueError("Expected transfer response to be non-null")
-    
+
+
 async def withdrawal_with_signing_async() -> None:
     api = GrvtRawAsync(config=get_config())
     withdrawal = get_test_withdrawal(api)
-    
+
     if withdrawal is None:
         return None  # Skip test if configs are not set
 

--- a/tests/pysdk/test_grvt_raw_signing.py
+++ b/tests/pysdk/test_grvt_raw_signing.py
@@ -9,7 +9,6 @@ from pysdk.grvt_raw_base import GrvtApiConfig
 from pysdk.grvt_raw_env import GrvtEnv
 from pysdk.grvt_raw_signing import sign_order, sign_transfer
 from pysdk.grvt_raw_types import (
-    Currency,
     Instrument,
     InstrumentSettlementPeriod,
     Kind,
@@ -179,8 +178,8 @@ def test_sign_order_table():
         "BTC_USDT_Perp": Instrument(
             instrument="BTC_USDT_Perp",
             instrument_hash="0x030501",
-            base=Currency.BTC,
-            quote=Currency.USDT,
+            base="BTC",
+            quote="USDT",
             kind=Kind.PERPETUAL,
             venues=[],
             settlement_period=InstrumentSettlementPeriod.DAILY,
@@ -239,7 +238,7 @@ def test_sign_transfer_table():
                 from_sub_account_id="0",
                 to_account_id=main_account_id,
                 to_sub_account_id=sub_account_id,
-                currency=Currency.USDT,
+                currency="USDT",
                 num_tokens="1",
                 signature=Signature(
                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
@@ -259,7 +258,7 @@ def test_sign_transfer_table():
                 from_sub_account_id="0",
                 to_account_id=main_account_id,
                 to_sub_account_id=sub_account_id,
-                currency=Currency.USDT,
+                currency="USDT",
                 num_tokens="1.5",
                 signature=Signature(
                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
@@ -279,7 +278,7 @@ def test_sign_transfer_table():
                 from_sub_account_id=sub_account_id,
                 to_account_id=main_account_id,
                 to_sub_account_id="0",
-                currency=Currency.USDT,
+                currency="USDT",
                 num_tokens="1",
                 signature=Signature(
                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
@@ -299,7 +298,7 @@ def test_sign_transfer_table():
                 from_sub_account_id=sub_account_id,
                 to_account_id=main_account_id,
                 to_sub_account_id="0",
-                currency=Currency.USDT,
+                currency="USDT",
                 num_tokens="1.5",
                 signature=Signature(
                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
@@ -319,7 +318,7 @@ def test_sign_transfer_table():
                 from_sub_account_id="0",
                 to_account_id="0x6a3434fce60ff567f60d80fb98f2f981e9b081fd",
                 to_sub_account_id="0",
-                currency=Currency.USDT,
+                currency="USDT",
                 num_tokens="1",
                 signature=Signature(
                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
@@ -339,7 +338,7 @@ def test_sign_transfer_table():
                 from_sub_account_id="0",
                 to_account_id="0x922a4874196806460fc63b5bcbff45f94c87f76f",
                 to_sub_account_id="0",
-                currency=Currency.USDT,
+                currency="USDT",
                 num_tokens="1.5",
                 signature=Signature(
                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce

--- a/tests/pysdk/test_grvt_raw_signing_intermediate_steps.py
+++ b/tests/pysdk/test_grvt_raw_signing_intermediate_steps.py
@@ -9,13 +9,22 @@ from pysdk.grvt_fixed_types import Transfer
 from pysdk.grvt_raw_base import GrvtApiConfig
 from pysdk.grvt_raw_env import GrvtEnv
 from pysdk.grvt_raw_signing import (
+    EIP712_ORDER_MESSAGE_TYPE,
     EIP712_TRANSFER_MESSAGE_TYPE,
+    build_EIP712_order_message_data,
     build_EIP712_transfer_message_data,
     get_EIP712_domain_data,
+    sign_order,
 )
 from pysdk.grvt_raw_types import (
-    Currency,
+    Instrument,
+    InstrumentSettlementPeriod,
+    Kind,
+    Order,
+    OrderLeg,
+    OrderMetadata,
     Signature,
+    TimeInForce,
     TransferType,
 )
 
@@ -25,395 +34,392 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-# TODO: Below test was temporarily commented out to support a currency release.
-# However, it should be fixed and re-enabled to guide integrators on order-signing implementation details.
-#
-# def test_sign_order_table():
-#     # Generated using https://key.tokenpocket.pro/#/?network=ETH
-#     # NOTE: `0x` hexadecimal prefix removed
-#     public_key = "ee2060eECaC18beC7F8F670D751801294911E445"
-#     private_key = "c0663ca94684aead40c41a1cb3a94b68a24296e87245be3a186e882a29a15ee0"
+def test_sign_order_table():
+    # Generated using https://key.tokenpocket.pro/#/?network=ETH
+    # NOTE: `0x` hexadecimal prefix removed
+    public_key = "ee2060eECaC18beC7F8F670D751801294911E445"
+    private_key = "c0663ca94684aead40c41a1cb3a94b68a24296e87245be3a186e882a29a15ee0"
 
-#     sub_account_id = "8289849667772468"
-#     expiry = 1730800479321350000
-#     nonce = 828700936
+    sub_account_id = "8289849667772468"
+    expiry = 1730800479321350000
+    nonce = 828700936
 
-#     test_cases = [
-#         {
-#             "name": "test decimal precision 1, 3 decimals",
-#             "order": Order(
-#                 metadata=OrderMetadata(
-#                     client_order_id="1", create_time="1730800479321350000"
-#                 ),
-#                 sub_account_id=sub_account_id,
-#                 time_in_force=TimeInForce.GOOD_TILL_TIME,
-#                 post_only=False,
-#                 is_market=False,
-#                 reduce_only=False,
-#                 legs=[
-#                     OrderLeg(
-#                         instrument="BTC_USDT_Perp",
-#                         size="1.013",
-#                         limit_price="68900.5",
-#                         is_buying_asset=False,
-#                     )
-#                 ],
-#                 signature=Signature(
-#                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
-#                 ),
-#             ),
-#             "expected_message_data_json": """
-# {
-#   "subAccountID": "8289849667772468",
-#   "isMarket": false,
-#   "timeInForce": 1,
-#   "postOnly": false,
-#   "reduceOnly": false,
-#   "legs": [
-#     {
-#       "assetID": "0x030501",
-#       "contractSize": 1013000000,
-#       "limitPrice": 68900500000000,
-#       "isBuyingContract": false
-#     }
-#   ],
-#   "nonce": 828700936,
-#   "expiration": 1730800479321350000
-# }""",
-#             "expected_domain_data_json": """
-# {
-#   "name": "GRVT Exchange",
-#   "version": "0",
-#   "chainId": 326
-# }""",
-#             # Per EIP-191: https://eips.ethereum.org/EIPS/eip-191
-#             "expected_signable_message": """
-# {
-#   "version": "01",
-#   "header": "1254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16",
-#   "body": "41650c08ab6e720f899307d7c2b4381a10c1301888375cec2dfefd6a583859eb"
-# }""",
-#             # EIP-712 signable message format: https://eips.ethereum.org/EIPS/eip-712
-#             # Pre-image of the signed message's message hash
-#             # encode(domainSeparator : 𝔹²⁵⁶, message : 𝕊) = "\x19"‖ version ‖ domainSeparator ‖ hashStruct(message)
-#             "digest_input": "0x19011254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f1641650c08ab6e720f899307d7c2b4381a10c1301888375cec2dfefd6a583859eb",
-#             "expected_signed_message": """
-# {
-#   "message_hash": "03cb7ca7b353969ab2c00ff92fd472f81f59a84d28fa1aa39128176f21062982",
-#   "r": 14615867946748605809126568669694142791729730263440553623296112010401671344650,
-#   "s": 41758084966111141828834491248882149351523023670747687501271185591898818786045,
-#   "v": 28,
-#   "signature": "205049c0db6e38fd88e4e46be81db7bc354520d52ec6268d210fa35b86c4f20a5c523d0ff8e6f12542fdcf34a6e6e2c547986b7c8fa53f86a5e656d9ab44b2fd1c"
-# }""",
-#         },
-#         {
-#             "name": "test decimal precision 2, 9 decimals",
-#             "order": Order(
-#                 metadata=OrderMetadata(
-#                     client_order_id="1", create_time="1730800479321350000"
-#                 ),
-#                 sub_account_id=sub_account_id,
-#                 time_in_force=TimeInForce.GOOD_TILL_TIME,
-#                 post_only=False,
-#                 is_market=False,
-#                 reduce_only=False,
-#                 legs=[
-#                     OrderLeg(
-#                         instrument="BTC_USDT_Perp",
-#                         size="1.123123123",
-#                         limit_price="68900.777123479",
-#                         is_buying_asset=False,
-#                     )
-#                 ],
-#                 signature=Signature(
-#                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
-#                 ),
-#             ),
-#             "expected_message_data_json": """
-# {
-#   "subAccountID": "8289849667772468",
-#   "isMarket": false,
-#   "timeInForce": 1,
-#   "postOnly": false,
-#   "reduceOnly": false,
-#   "legs": [
-#     {
-#       "assetID": "0x030501",
-#       "contractSize": 1123123123,
-#       "limitPrice": 68900777123479,
-#       "isBuyingContract": false
-#     }
-#   ],
-#   "nonce": 828700936,
-#   "expiration": 1730800479321350000
-# }""",
-#             "expected_domain_data_json": """
-# {
-#   "name": "GRVT Exchange",
-#   "version": "0",
-#   "chainId": 326
-# }""",
-#             "expected_signable_message": """
-# {
-#   "version": "01",
-#   "header": "1254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16",
-#   "body": "e85ffec169d4ebd4b8057e5fbd31ed31d4511b2f2299bbce0adab6beb5fe2814"
-# }""",
-#             "digest_input": "0x19011254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16e85ffec169d4ebd4b8057e5fbd31ed31d4511b2f2299bbce0adab6beb5fe2814",
-#             "expected_signed_message": """
-# {
-#   "message_hash": "2d0a437f7d64523386974c2a729d69604f8e2a7f0684b7de923845d8b175ab69",
-#   "r": 30067953785684815030293507105225786115862149795459199007947867478230986262090,
-#   "s": 23299979093064779986156565292425191814752388247725004533191995996670719399433,
-#   "v": 28,
-#   "signature": "4279dbd734584fb07b016bce7d9f029e7f7f80e378dc65cddc06aa6b0c9e064a33835221a0fbcb700de3068169b45572a27756bff479f2887e8c89139e6f96091c"
-# }""",
-#         },
-#         {
-#             "name": "test decimal precision 3, round down",
-#             "order": Order(
-#                 metadata=OrderMetadata(
-#                     client_order_id="1", create_time="1730800479321350000"
-#                 ),
-#                 sub_account_id=sub_account_id,
-#                 time_in_force=TimeInForce.GOOD_TILL_TIME,
-#                 post_only=False,
-#                 is_market=False,
-#                 reduce_only=False,
-#                 legs=[
-#                     OrderLeg(
-#                         instrument="BTC_USDT_Perp",
-#                         size="1.1231231234",
-#                         limit_price="68900.7771234794",
-#                         is_buying_asset=False,
-#                     )
-#                 ],
-#                 signature=Signature(
-#                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
-#                 ),
-#             ),
-#             "expected_message_data_json": """
-# {
-#   "subAccountID": "8289849667772468",
-#   "isMarket": false,
-#   "timeInForce": 1,
-#   "postOnly": false,
-#   "reduceOnly": false,
-#   "legs": [
-#     {
-#       "assetID": "0x030501",
-#       "contractSize": 1123123123,
-#       "limitPrice": 68900777123479,
-#       "isBuyingContract": false
-#     }
-#   ],
-#   "nonce": 828700936,
-#   "expiration": 1730800479321350000
-# }""",
-#             "expected_domain_data_json": """
-# {
-#   "name": "GRVT Exchange",
-#   "version": "0",
-#   "chainId": 326
-# }""",
-#             "expected_signable_message": """
-# {
-#   "version": "01",
-#   "header": "1254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16",
-#   "body": "e85ffec169d4ebd4b8057e5fbd31ed31d4511b2f2299bbce0adab6beb5fe2814"
-# }""",
-#             "digest_input": "0x19011254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16e85ffec169d4ebd4b8057e5fbd31ed31d4511b2f2299bbce0adab6beb5fe2814",
-#             "expected_signed_message": """
-# {
-#   "message_hash": "2d0a437f7d64523386974c2a729d69604f8e2a7f0684b7de923845d8b175ab69",
-#   "r": 30067953785684815030293507105225786115862149795459199007947867478230986262090,
-#   "s": 23299979093064779986156565292425191814752388247725004533191995996670719399433,
-#   "v": 28,
-#   "signature": "4279dbd734584fb07b016bce7d9f029e7f7f80e378dc65cddc06aa6b0c9e064a33835221a0fbcb700de3068169b45572a27756bff479f2887e8c89139e6f96091c"
-# }""",
-#         },
-#         {
-#             "name": "test decimal precision 4, round down",
-#             "order": Order(
-#                 metadata=OrderMetadata(
-#                     client_order_id="1", create_time="1730800479321350000"
-#                 ),
-#                 sub_account_id=sub_account_id,
-#                 time_in_force=TimeInForce.GOOD_TILL_TIME,
-#                 post_only=False,
-#                 is_market=False,
-#                 reduce_only=False,
-#                 legs=[
-#                     OrderLeg(
-#                         instrument="BTC_USDT_Perp",
-#                         size="1.1231231239",
-#                         limit_price="68900.7771234799",
-#                         is_buying_asset=False,
-#                     )
-#                 ],
-#                 signature=Signature(
-#                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
-#                 ),
-#             ),
-#             "expected_message_data_json": """
-# {
-#   "subAccountID": "8289849667772468",
-#   "isMarket": false,
-#   "timeInForce": 1,
-#   "postOnly": false,
-#   "reduceOnly": false,
-#   "legs": [
-#     {
-#       "assetID": "0x030501",
-#       "contractSize": 1123123123,
-#       "limitPrice": 68900777123479,
-#       "isBuyingContract": false
-#     }
-#   ],
-#   "nonce": 828700936,
-#   "expiration": 1730800479321350000
-# }""",
-#             "expected_domain_data_json": """
-# {
-#   "name": "GRVT Exchange",
-#   "version": "0",
-#   "chainId": 326
-# }""",
-#             "expected_signable_message": """
-# {
-#   "version": "01",
-#   "header": "1254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16",
-#   "body": "e85ffec169d4ebd4b8057e5fbd31ed31d4511b2f2299bbce0adab6beb5fe2814"
-# }""",
-#             "digest_input": "0x19011254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16e85ffec169d4ebd4b8057e5fbd31ed31d4511b2f2299bbce0adab6beb5fe2814",
-#             "expected_signed_message": """
-# {
-#   "message_hash": "2d0a437f7d64523386974c2a729d69604f8e2a7f0684b7de923845d8b175ab69",
-#   "r": 30067953785684815030293507105225786115862149795459199007947867478230986262090,
-#   "s": 23299979093064779986156565292425191814752388247725004533191995996670719399433,
-#   "v": 28,
-#   "signature": "4279dbd734584fb07b016bce7d9f029e7f7f80e378dc65cddc06aa6b0c9e064a33835221a0fbcb700de3068169b45572a27756bff479f2887e8c89139e6f96091c"
-# }""",
-#         },
-#     ]
+    test_cases = [
+        {
+            "name": "test decimal precision 1, 3 decimals",
+            "order": Order(
+                metadata=OrderMetadata(
+                    client_order_id="1", create_time="1730800479321350000"
+                ),
+                sub_account_id=sub_account_id,
+                time_in_force=TimeInForce.GOOD_TILL_TIME,
+                post_only=False,
+                is_market=False,
+                reduce_only=False,
+                legs=[
+                    OrderLeg(
+                        instrument="BTC_USDT_Perp",
+                        size="1.013",
+                        limit_price="68900.5",
+                        is_buying_asset=False,
+                    )
+                ],
+                signature=Signature(
+                    signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
+                ),
+            ),
+            "expected_message_data_json": """
+{
+  "subAccountID": "8289849667772468",
+  "isMarket": false,
+  "timeInForce": 1,
+  "postOnly": false,
+  "reduceOnly": false,
+  "legs": [
+    {
+      "assetID": "0x030501",
+      "contractSize": 1013000000,
+      "limitPrice": 68900500000000,
+      "isBuyingContract": false
+    }
+  ],
+  "nonce": 828700936,
+  "expiration": 1730800479321350000
+}""",
+            "expected_domain_data_json": """
+{
+  "name": "GRVT Exchange",
+  "version": "0",
+  "chainId": 326
+}""",
+            # Per EIP-191: https://eips.ethereum.org/EIPS/eip-191
+            "expected_signable_message": """
+{
+  "version": "01",
+  "header": "1254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16",
+  "body": "41650c08ab6e720f899307d7c2b4381a10c1301888375cec2dfefd6a583859eb"
+}""",
+            # EIP-712 signable message format: https://eips.ethereum.org/EIPS/eip-712
+            # Pre-image of the signed message's message hash
+            # encode(domainSeparator : 𝔹²⁵⁶, message : 𝕊) = "\x19"‖ version ‖ domainSeparator ‖ hashStruct(message)
+            "digest_input": "0x19011254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f1641650c08ab6e720f899307d7c2b4381a10c1301888375cec2dfefd6a583859eb",
+            "expected_signed_message": """
+{
+  "message_hash": "03cb7ca7b353969ab2c00ff92fd472f81f59a84d28fa1aa39128176f21062982",
+  "r": 14615867946748605809126568669694142791729730263440553623296112010401671344650,
+  "s": 41758084966111141828834491248882149351523023670747687501271185591898818786045,
+  "v": 28,
+  "signature": "205049c0db6e38fd88e4e46be81db7bc354520d52ec6268d210fa35b86c4f20a5c523d0ff8e6f12542fdcf34a6e6e2c547986b7c8fa53f86a5e656d9ab44b2fd1c"
+}""",
+        },
+        {
+            "name": "test decimal precision 2, 9 decimals",
+            "order": Order(
+                metadata=OrderMetadata(
+                    client_order_id="1", create_time="1730800479321350000"
+                ),
+                sub_account_id=sub_account_id,
+                time_in_force=TimeInForce.GOOD_TILL_TIME,
+                post_only=False,
+                is_market=False,
+                reduce_only=False,
+                legs=[
+                    OrderLeg(
+                        instrument="BTC_USDT_Perp",
+                        size="1.123123123",
+                        limit_price="68900.777123479",
+                        is_buying_asset=False,
+                    )
+                ],
+                signature=Signature(
+                    signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
+                ),
+            ),
+            "expected_message_data_json": """
+{
+  "subAccountID": "8289849667772468",
+  "isMarket": false,
+  "timeInForce": 1,
+  "postOnly": false,
+  "reduceOnly": false,
+  "legs": [
+    {
+      "assetID": "0x030501",
+      "contractSize": 1123123123,
+      "limitPrice": 68900777123479,
+      "isBuyingContract": false
+    }
+  ],
+  "nonce": 828700936,
+  "expiration": 1730800479321350000
+}""",
+            "expected_domain_data_json": """
+{
+  "name": "GRVT Exchange",
+  "version": "0",
+  "chainId": 326
+}""",
+            "expected_signable_message": """
+{
+  "version": "01",
+  "header": "1254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16",
+  "body": "e85ffec169d4ebd4b8057e5fbd31ed31d4511b2f2299bbce0adab6beb5fe2814"
+}""",
+            "digest_input": "0x19011254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16e85ffec169d4ebd4b8057e5fbd31ed31d4511b2f2299bbce0adab6beb5fe2814",
+            "expected_signed_message": """
+{
+  "message_hash": "2d0a437f7d64523386974c2a729d69604f8e2a7f0684b7de923845d8b175ab69",
+  "r": 30067953785684815030293507105225786115862149795459199007947867478230986262090,
+  "s": 23299979093064779986156565292425191814752388247725004533191995996670719399433,
+  "v": 28,
+  "signature": "4279dbd734584fb07b016bce7d9f029e7f7f80e378dc65cddc06aa6b0c9e064a33835221a0fbcb700de3068169b45572a27756bff479f2887e8c89139e6f96091c"
+}""",
+        },
+        {
+            "name": "test decimal precision 3, round down",
+            "order": Order(
+                metadata=OrderMetadata(
+                    client_order_id="1", create_time="1730800479321350000"
+                ),
+                sub_account_id=sub_account_id,
+                time_in_force=TimeInForce.GOOD_TILL_TIME,
+                post_only=False,
+                is_market=False,
+                reduce_only=False,
+                legs=[
+                    OrderLeg(
+                        instrument="BTC_USDT_Perp",
+                        size="1.1231231234",
+                        limit_price="68900.7771234794",
+                        is_buying_asset=False,
+                    )
+                ],
+                signature=Signature(
+                    signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
+                ),
+            ),
+            "expected_message_data_json": """
+{
+  "subAccountID": "8289849667772468",
+  "isMarket": false,
+  "timeInForce": 1,
+  "postOnly": false,
+  "reduceOnly": false,
+  "legs": [
+    {
+      "assetID": "0x030501",
+      "contractSize": 1123123123,
+      "limitPrice": 68900777123479,
+      "isBuyingContract": false
+    }
+  ],
+  "nonce": 828700936,
+  "expiration": 1730800479321350000
+}""",
+            "expected_domain_data_json": """
+{
+  "name": "GRVT Exchange",
+  "version": "0",
+  "chainId": 326
+}""",
+            "expected_signable_message": """
+{
+  "version": "01",
+  "header": "1254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16",
+  "body": "e85ffec169d4ebd4b8057e5fbd31ed31d4511b2f2299bbce0adab6beb5fe2814"
+}""",
+            "digest_input": "0x19011254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16e85ffec169d4ebd4b8057e5fbd31ed31d4511b2f2299bbce0adab6beb5fe2814",
+            "expected_signed_message": """
+{
+  "message_hash": "2d0a437f7d64523386974c2a729d69604f8e2a7f0684b7de923845d8b175ab69",
+  "r": 30067953785684815030293507105225786115862149795459199007947867478230986262090,
+  "s": 23299979093064779986156565292425191814752388247725004533191995996670719399433,
+  "v": 28,
+  "signature": "4279dbd734584fb07b016bce7d9f029e7f7f80e378dc65cddc06aa6b0c9e064a33835221a0fbcb700de3068169b45572a27756bff479f2887e8c89139e6f96091c"
+}""",
+        },
+        {
+            "name": "test decimal precision 4, round down",
+            "order": Order(
+                metadata=OrderMetadata(
+                    client_order_id="1", create_time="1730800479321350000"
+                ),
+                sub_account_id=sub_account_id,
+                time_in_force=TimeInForce.GOOD_TILL_TIME,
+                post_only=False,
+                is_market=False,
+                reduce_only=False,
+                legs=[
+                    OrderLeg(
+                        instrument="BTC_USDT_Perp",
+                        size="1.1231231239",
+                        limit_price="68900.7771234799",
+                        is_buying_asset=False,
+                    )
+                ],
+                signature=Signature(
+                    signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
+                ),
+            ),
+            "expected_message_data_json": """
+{
+  "subAccountID": "8289849667772468",
+  "isMarket": false,
+  "timeInForce": 1,
+  "postOnly": false,
+  "reduceOnly": false,
+  "legs": [
+    {
+      "assetID": "0x030501",
+      "contractSize": 1123123123,
+      "limitPrice": 68900777123479,
+      "isBuyingContract": false
+    }
+  ],
+  "nonce": 828700936,
+  "expiration": 1730800479321350000
+}""",
+            "expected_domain_data_json": """
+{
+  "name": "GRVT Exchange",
+  "version": "0",
+  "chainId": 326
+}""",
+            "expected_signable_message": """
+{
+  "version": "01",
+  "header": "1254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16",
+  "body": "e85ffec169d4ebd4b8057e5fbd31ed31d4511b2f2299bbce0adab6beb5fe2814"
+}""",
+            "digest_input": "0x19011254f97f8495f704630a238cbcd898a4b8ab20d77bb93e17049d3445f4f81f16e85ffec169d4ebd4b8057e5fbd31ed31d4511b2f2299bbce0adab6beb5fe2814",
+            "expected_signed_message": """
+{
+  "message_hash": "2d0a437f7d64523386974c2a729d69604f8e2a7f0684b7de923845d8b175ab69",
+  "r": 30067953785684815030293507105225786115862149795459199007947867478230986262090,
+  "s": 23299979093064779986156565292425191814752388247725004533191995996670719399433,
+  "v": 28,
+  "signature": "4279dbd734584fb07b016bce7d9f029e7f7f80e378dc65cddc06aa6b0c9e064a33835221a0fbcb700de3068169b45572a27756bff479f2887e8c89139e6f96091c"
+}""",
+        },
+    ]
 
-#     account = Account.from_key(private_key)
+    account = Account.from_key(private_key)
 
-#     instruments = {
-#         "BTC_USDT_Perp": Instrument(
-#             instrument="BTC_USDT_Perp",
-#             instrument_hash="0x030501",
-#             base=Currency.BTC,
-#             quote=Currency.USDT,
-#             kind=Kind.PERPETUAL,
-#             venues=[],
-#             settlement_period=InstrumentSettlementPeriod.DAILY,
-#             tick_size="0.00000001",
-#             min_size="0.00000001",
-#             create_time="123",
-#             base_decimals=9,
-#             quote_decimals=9,
-#             max_position_size="1000000",
-#         )
-#     }
+    instruments = {
+        "BTC_USDT_Perp": Instrument(
+            instrument="BTC_USDT_Perp",
+            instrument_hash="0x030501",
+            base="BTC",
+            quote="USDT",
+            kind=Kind.PERPETUAL,
+            venues=[],
+            settlement_period=InstrumentSettlementPeriod.DAILY,
+            tick_size="0.00000001",
+            min_size="0.00000001",
+            create_time="123",
+            base_decimals=9,
+            quote_decimals=9,
+            max_position_size="1000000",
+        )
+    }
 
-#     for tc in test_cases:
-#         config = GrvtApiConfig(
-#             env=GrvtEnv.TESTNET,
-#             private_key=private_key,
-#             trading_account_id=sub_account_id,
-#             api_key="not-needed",
-#             logger=logger,
-#         )
+    for tc in test_cases:
+        config = GrvtApiConfig(
+            env=GrvtEnv.TESTNET,
+            private_key=private_key,
+            trading_account_id=sub_account_id,
+            api_key="not-needed",
+            logger=logger,
+        )
 
-#         # Get intermediate values
-#         message_data = build_EIP712_order_message_data(tc["order"], instruments)
-#         domain_data = get_EIP712_domain_data(config.env)
-#         signable_message = encode_typed_data(
-#             domain_data, EIP712_ORDER_MESSAGE_TYPE, message_data
-#         )
-#         signed_message = account.sign_message(signable_message)
-#         signed_order = sign_order(tc["order"], config, account, instruments)
+        # Get intermediate values
+        message_data = build_EIP712_order_message_data(tc["order"], instruments)
+        domain_data = get_EIP712_domain_data(config.env, 326)
+        signable_message = encode_typed_data(
+            domain_data, EIP712_ORDER_MESSAGE_TYPE, message_data
+        )
+        signed_message = account.sign_message(signable_message)
+        signed_order = sign_order(tc["order"], config, account, instruments)
 
-#         # Convert to comparable strings
-#         message_data_json = json.dumps(message_data, indent=2)
-#         domain_data_json = json.dumps(domain_data, indent=2)
-#         signable_message_json = json.dumps(
-#             {
-#                 "version": signable_message.version.hex(),
-#                 "header": signable_message.header.hex(),
-#                 "body": signable_message.body.hex(),
-#             },
-#             indent=2,
-#         )
-#         signed_message_json = json.dumps(
-#             {
-#                 "message_hash": signed_message.message_hash.hex(),
-#                 "r": signed_message.r,
-#                 "s": signed_message.s,
-#                 "v": signed_message.v,
-#                 "signature": signed_message.signature.hex(),
-#             },
-#             indent=2,
-#         )
-#         # EIP-712 signable message format: https://eips.ethereum.org/EIPS/eip-712
-#         signed_message_hash_preimage = (
-#             "0x19"
-#             + signable_message.version.hex()
-#             + signable_message.header.hex()
-#             + signable_message.body.hex()
-#         )
+        # Convert to comparable strings
+        message_data_json = json.dumps(message_data, indent=2)
+        domain_data_json = json.dumps(domain_data, indent=2)
+        signable_message_json = json.dumps(
+            {
+                "version": signable_message.version.hex(),
+                "header": signable_message.header.hex(),
+                "body": signable_message.body.hex(),
+            },
+            indent=2,
+        )
+        signed_message_json = json.dumps(
+            {
+                "message_hash": signed_message.message_hash.hex(),
+                "r": signed_message.r,
+                "s": signed_message.s,
+                "v": signed_message.v,
+                "signature": signed_message.signature.hex(),
+            },
+            indent=2,
+        )
+        # EIP-712 signable message format: https://eips.ethereum.org/EIPS/eip-712
+        signed_message_hash_preimage = (
+            "0x19"
+            + signable_message.version.hex()
+            + signable_message.header.hex()
+            + signable_message.body.hex()
+        )
 
-#         # Strip whitespace for comparison
-#         assert (
-#             message_data_json.strip() == tc["expected_message_data_json"].strip()
-#         ), f"""
-# Test '{tc['name']}' failed: message_data mismatch.
-# Wanted:
-# {tc['expected_message_data_json'].strip()}
-# Got:
-# {message_data_json.strip()}
-# """
-#         assert (
-#             domain_data_json.strip() == tc["expected_domain_data_json"].strip()
-#         ), f"""
-# Test '{tc['name']}' failed: domain_data mismatch.
-# Wanted:
-# {tc['expected_domain_data_json'].strip()}
-# Got:
-# {domain_data_json.strip()}
-# """
-#         assert (
-#             signable_message_json.strip() == tc["expected_signable_message"].strip()
-#         ), f"""
-# Test '{tc['name']}' failed: signable_message mismatch.
-# Wanted:
-# {tc['expected_signable_message'].strip()}
-# Got:
-# {signable_message_json.strip()}
-# """
-#         assert (
-#             signed_message_hash_preimage.strip() == tc["digest_input"].strip()
-#         ), f"""
-# Test '{tc['name']}' failed: digest_input mismatch.
-# Wanted:
-# {tc["digest_input"].strip()
-# }
-# Got:
-# {signed_message_hash_preimage.strip()}
-# """
-#         assert (
-#             signed_message_json.strip() == tc["expected_signed_message"].strip()
-#         ), f"""
-# Test '{tc['name']}' failed: signed_message mismatch.
-# Wanted:
-# {tc['expected_signed_message'].strip()}
-# Got:
-# {signed_message_json.strip()}
-# """
-#         assert (
-#             signed_order.signature.signer == str(account.address) == "0x" + public_key
-#         ), f"""Test '{tc['name']}' failed: signer mismatch."""
+        # Strip whitespace for comparison
+        assert (
+            message_data_json.strip() == tc["expected_message_data_json"].strip()
+        ), f"""
+Test '{tc['name']}' failed: message_data mismatch.
+Wanted:
+{tc['expected_message_data_json'].strip()}
+Got:
+{message_data_json.strip()}
+"""
+        assert (
+            domain_data_json.strip() == tc["expected_domain_data_json"].strip()
+        ), f"""
+Test '{tc['name']}' failed: domain_data mismatch.
+Wanted:
+{tc['expected_domain_data_json'].strip()}
+Got:
+{domain_data_json.strip()}
+"""
+        assert (
+            signable_message_json.strip() == tc["expected_signable_message"].strip()
+        ), f"""
+Test '{tc['name']}' failed: signable_message mismatch.
+Wanted:
+{tc['expected_signable_message'].strip()}
+Got:
+{signable_message_json.strip()}
+"""
+        assert (
+            signed_message_hash_preimage.strip() == tc["digest_input"].strip()
+        ), f"""
+Test '{tc['name']}' failed: digest_input mismatch.
+Wanted:
+{tc["digest_input"].strip()
+}
+Got:
+{signed_message_hash_preimage.strip()}
+"""
+        assert (
+            signed_message_json.strip() == tc["expected_signed_message"].strip()
+        ), f"""
+Test '{tc['name']}' failed: signed_message mismatch.
+Wanted:
+{tc['expected_signed_message'].strip()}
+Got:
+{signed_message_json.strip()}
+"""
+        assert (
+            signed_order.signature.signer == str(account.address) == "0x" + public_key
+        ), f"""Test '{tc['name']}' failed: signer mismatch."""
 
 
 def test_sign_transfer_table():
@@ -432,7 +438,7 @@ def test_sign_transfer_table():
                 from_sub_account_id="0",
                 to_account_id=main_account_id,
                 to_sub_account_id=sub_account_id,
-                currency=Currency.USDT,
+                currency="USDT",
                 num_tokens="1",
                 signature=Signature(
                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
@@ -484,7 +490,7 @@ def test_sign_transfer_table():
                 from_sub_account_id="0",
                 to_account_id=main_account_id,
                 to_sub_account_id=sub_account_id,
-                currency=Currency.USDT,
+                currency="USDT",
                 num_tokens="1.5",
                 signature=Signature(
                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
@@ -532,7 +538,7 @@ def test_sign_transfer_table():
                 from_sub_account_id=sub_account_id,
                 to_account_id=main_account_id,
                 to_sub_account_id="0",
-                currency=Currency.USDT,
+                currency="USDT",
                 num_tokens="1",
                 signature=Signature(
                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
@@ -580,7 +586,7 @@ def test_sign_transfer_table():
                 from_sub_account_id=sub_account_id,
                 to_account_id=main_account_id,
                 to_sub_account_id="0",
-                currency=Currency.USDT,
+                currency="USDT",
                 num_tokens="1.5",
                 signature=Signature(
                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
@@ -628,7 +634,7 @@ def test_sign_transfer_table():
                 from_sub_account_id="0",
                 to_account_id="0x6a3434fce60ff567f60d80fb98f2f981e9b081fd",
                 to_sub_account_id="0",
-                currency=Currency.USDT,
+                currency="USDT",
                 num_tokens="1",
                 signature=Signature(
                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
@@ -676,7 +682,7 @@ def test_sign_transfer_table():
                 from_sub_account_id="0",
                 to_account_id="0x922a4874196806460fc63b5bcbff45f94c87f76f",
                 to_sub_account_id="0",
-                currency=Currency.USDT,
+                currency="USDT",
                 num_tokens="1.5",
                 signature=Signature(
                     signer="", r="", s="", v=0, expiration=expiry, nonce=nonce
@@ -729,7 +735,9 @@ def test_sign_transfer_table():
     )
 
     for tc in test_cases:
-        message_data = build_EIP712_transfer_message_data(tc["transfer"])
+        message_data = build_EIP712_transfer_message_data(
+            tc["transfer"], 3  # assume all test cases are USDT transfers
+        )
         domain_data = get_EIP712_domain_data(config.env, chainId)
         signable_message = encode_typed_data(
             domain_data, EIP712_TRANSFER_MESSAGE_TYPE, message_data

--- a/tests/pysdk/test_grvt_raw_sync.py
+++ b/tests/pysdk/test_grvt_raw_sync.py
@@ -13,7 +13,9 @@ from .test_raw_utils import (
 
 def test_get_all_instruments() -> None:
     api = GrvtRawSync(config=get_config())
-    resp = api.get_all_instruments_v1(grvt_raw_types.ApiGetAllInstrumentsRequest(is_active=True))
+    resp = api.get_all_instruments_v1(
+        grvt_raw_types.ApiGetAllInstrumentsRequest(is_active=True)
+    )
     if isinstance(resp, GrvtError):
         raise ValueError(f"Received error: {resp}")
     if resp.result is None:
@@ -34,8 +36,8 @@ def test_open_orders() -> None:
             # sub_account_id=233, Uncomment to test error path with invalid sub account id
             sub_account_id=str(api.config.trading_account_id),
             kind=[grvt_raw_types.Kind.PERPETUAL],
-            base=[grvt_raw_types.Currency.BTC, grvt_raw_types.Currency.ETH],
-            quote=[grvt_raw_types.Currency.USDT],
+            base=["BTC", "ETH"],
+            quote=["USDT"],
         )
     )
     if isinstance(resp, GrvtError):
@@ -76,7 +78,9 @@ def test_create_tpsl_order_with_signing() -> None:
     if isinstance(inst_resp, GrvtError):
         raise ValueError(f"Received error: {inst_resp}")
 
-    order = get_test_tpsl_order(api, {inst.instrument: inst for inst in inst_resp.result})
+    order = get_test_tpsl_order(
+        api, {inst.instrument: inst for inst in inst_resp.result}
+    )
     if order is None:
         return None  # Skip test if configs are not set
     resp = api.create_order_v1(grvt_raw_types.ApiCreateOrderRequest(order=order))
@@ -103,6 +107,8 @@ def test_transfer_with_signing() -> None:
             transfer.currency,
             transfer.num_tokens,
             transfer.signature,
+            grvt_raw_types.TransferType.STANDARD,
+            "",
         )
     )
 

--- a/tests/pysdk/test_raw_utils.py
+++ b/tests/pysdk/test_raw_utils.py
@@ -105,7 +105,7 @@ def get_test_transfer(api: GrvtRawSync) -> grvt_fixed_types.Transfer | None:
             from_sub_account_id="0",
             to_account_id=funding_account_address,
             to_sub_account_id=str(api.config.trading_account_id),
-            currency=grvt_raw_types.Currency.USDT,
+            currency="USDT",
             num_tokens="1",
             signature=grvt_raw_types.Signature(
                 signer="",
@@ -140,7 +140,7 @@ def get_test_withdrawal(api: GrvtRawSync) -> grvt_raw_types.Withdrawal | None:
         grvt_raw_types.Withdrawal(
             from_account_id=funding_account_address,
             to_eth_address="0xed3FF6F4E84a64556e8F7d149dC3533f0c7D9c49",  # Just a test address
-            currency=grvt_raw_types.Currency.USDT,
+            currency="USDT",
             num_tokens="1",
             signature=grvt_raw_types.Signature(
                 signer="",


### PR DESCRIPTION
- Removal of Currency enum (with associated update to signing implementation)
- Vault Management endpoints
- Added get-currency endpoint

NOTE: SDK tests were run against GRVT's `dev` environment, not `testnet` as usual, given that our testnet is currently unavailable. Test run results below:
```
❯ make test
zsh: correct 'test' to 'tests' [nyae]? n
uv run pytest tests --cov=src
=============================================================================================================== test session starts ===============================================================================================================
platform darwin -- Python 3.10.16, pytest-8.3.4, pluggy-1.5.0 -- /Users/keithang/code/grvt/grvt-pysdk/.venv/bin/python3
cachedir: .pytest_cache
rootdir: grvt/grvt-pysdk
configfile: pyproject.toml
plugins: cov-6.0.0
collected 19 items
                                                                                                                                                                                                                                                   
tests/pysdk/test_grvt_ccxt.py::test_grvt_ccxt PASSED                                                                                                                                                                                        [  5%]
tests/pysdk/test_grvt_ccxt_pro.py::test_grvt_ccxt_pro PASSED                                                                                                                                                                                [ 10%]
tests/pysdk/test_grvt_raw_async.py::test_get_all_instruments PASSED                                                                                                                                                                         [ 15%]
tests/pysdk/test_grvt_raw_async.py::test_open_orders PASSED                                                                                                                                                                                 [ 21%]
tests/pysdk/test_grvt_raw_async.py::test_create_order_with_signing PASSED                                                                                                                                                                   [ 26%]
tests/pysdk/test_grvt_raw_async.py::test_transfer_with_signing_async PASSED                                                                                                                                                                 [ 31%]
tests/pysdk/test_grvt_raw_async.py::test_withdrawal_with_signing_async PASSED                                                                                                                                                               [ 36%]
tests/pysdk/test_grvt_raw_signing.py::test_sign_order_table PASSED                                                                                                                                                                          [ 42%]
tests/pysdk/test_grvt_raw_signing.py::test_sign_transfer_table PASSED                                                                                                                                                                       [ 47%]
tests/pysdk/test_grvt_raw_signing_intermediate_steps.py::test_sign_order_table PASSED                                                                                                                                                       [ 52%]
tests/pysdk/test_grvt_raw_signing_intermediate_steps.py::test_sign_transfer_table PASSED                                                                                                                                                    [ 57%]
tests/pysdk/test_grvt_raw_sync.py::test_get_all_instruments PASSED                                                                                                                                                                          [ 63%]
tests/pysdk/test_grvt_raw_sync.py::test_open_orders PASSED                                                                                                                                                                                  [ 68%]
tests/pysdk/test_grvt_raw_sync.py::test_create_order_with_signing PASSED                                                                                                                                                                    [ 73%]
tests/pysdk/test_grvt_raw_sync.py::test_create_tpsl_order_with_signing PASSED                                                                                                                                                               [ 78%]
tests/pysdk/test_grvt_raw_sync.py::test_transfer_with_signing PASSED                                                                                                                                                                        [ 84%]
tests/pysdk/test_grvt_raw_sync.py::test_withdrawal_with_signing PASSED                                                                                                                                                                      [ 89%]
tests/pysdk/test_transfer.py::test_transfer_with_signing <- tests/pysdk/test_grvt_raw_sync.py PASSED                                                                                                                                        [ 94%]
tests/pysdk/test_withdrawal.py::test_withdrawal_with_signing <- tests/pysdk/test_grvt_raw_sync.py PASSED                                                                                                                                    [100%]
                                                                                                                                                                                                                                                   
--------- coverage: platform darwin, python 3.10.16-final-0 ----------
Name                                      Stmts   Miss  Cover
-------------------------------------------------------------
src/pysdk/__init__.py                         0      0   100%
src/pysdk/grvt_ccxt.py                      248    114    54%
src/pysdk/grvt_ccxt_base.py                 236    145    39%
src/pysdk/grvt_ccxt_env.py                   55     17    69%
src/pysdk/grvt_ccxt_logging_selector.py      20     10    50%
src/pysdk/grvt_ccxt_pro.py                  253    118    53%
src/pysdk/grvt_ccxt_test_utils.py            36      5    86%
src/pysdk/grvt_ccxt_types.py                 42      0   100%
src/pysdk/grvt_ccxt_utils.py                203     87    57%
src/pysdk/grvt_ccxt_ws.py                   309    265    14%
src/pysdk/grvt_fixed_types.py                13      0   100%
src/pysdk/grvt_raw_async.py                 204    153    25%
src/pysdk/grvt_raw_base.py                  163     78    52%
src/pysdk/grvt_raw_env.py                    27      4    85%
src/pysdk/grvt_raw_signing.py                71     14    80%
src/pysdk/grvt_raw_sync.py                  204    153    25%
src/pysdk/grvt_raw_types.py                1054      0   100%
-------------------------------------------------------------
TOTAL                                      3138   1163    63%


=============================================================================================================== 19 passed in 39.75s ===============================================================================================================
```