### PR TITLE
feat(sdk): auto-set trading_account_id from login response

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,12 @@ Setup these environment variables:
 ```bash
 export GRVT_PRIVATE_KEY="`Secret Private Key` in API setup"
 export GRVT_API_KEY="`API Key` in API setup"
-export GRVT_TRADING_ACCOUNT_ID=<`Trading account ID` in API>
 export GRVT_ENV="testnet"
 export GRVT_END_POINT_VERSION="v1"
 export GRVT_WS_STREAM_VERSION="v1"
 ```
+
+> **Note:** `trading_account_id` is automatically retrieved from the login response. You can still pass it explicitly in `parameters` if needed.
 
 ## Usage
 

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -93,11 +93,12 @@ Setup these environment variables:
 ```bash
 export GRVT_PRIVATE_KEY="`Secret Private Key` in API setup"
 export GRVT_API_KEY="`API Key` in API setup"
-export GRVT_TRADING_ACCOUNT_ID=<`Trading account ID` in API>
 export GRVT_ENV="testnet"
 export GRVT_END_POINT_VERSION="v1"
 export GRVT_WS_STREAM_VERSION="v1"
 ```
+
+> **Note:** `trading_account_id` is automatically retrieved from the login response. You can still pass it explicitly in `parameters` if needed.
 
 ## Usage
 

--- a/src/pysdk/grvt_ccxt.py
+++ b/src/pysdk/grvt_ccxt.py
@@ -59,6 +59,7 @@ class GrvtCcxt(GrvtCcxtBase):
         self._session: requests.Session = requests.Session()
         self._session.headers.update({"Content-Type": "application/json"})
         self.refresh_cookie()
+        self._set_trading_account_id_from_cookie()
         # Assign markets here
         self.markets: dict[str, dict] = self.load_markets()
 
@@ -75,6 +76,7 @@ class GrvtCcxt(GrvtCcxtBase):
                 self._session.headers.update(
                     {"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]}
                 )
+            self._set_trading_account_id_from_cookie()
             self.logger.info(
                 f"refresh_cookie {self._cookie=} {self._session.cookies=} {self._session.headers=}"
             )

--- a/src/pysdk/grvt_ccxt_base.py
+++ b/src/pysdk/grvt_ccxt_base.py
@@ -93,6 +93,12 @@ class GrvtCcxtBase:
         """Returns the trading account id."""
         return self._trading_account_id or ""
 
+    def _set_trading_account_id_from_cookie(self) -> None:
+        """Sets trading_account_id from login response if not explicitly provided."""
+        if not self._trading_account_id and self._cookie and self._cookie.get("trading_account_id"):
+            self._trading_account_id = self._cookie["trading_account_id"]
+            self.logger.info(f"trading_account_id set from login: {self._trading_account_id}")
+
     def is_order_book_ccxt_format(self) -> bool:
         """Returns True if order book should be returned in CCXT format."""
         return self._order_book_ccxt_format

--- a/src/pysdk/grvt_ccxt_pro.py
+++ b/src/pysdk/grvt_ccxt_pro.py
@@ -66,6 +66,7 @@ class GrvtCcxtPro(GrvtCcxtBase):
         self._cookie = get_cookie_with_expiration(
             get_grvt_endpoint(self.env, "AUTH"), self._api_key
         )
+        self._set_trading_account_id_from_cookie()
         self.update_session_with_cookie()
 
     def __del__(self):
@@ -82,6 +83,7 @@ class GrvtCcxtPro(GrvtCcxtBase):
                 self._session.headers.update(
                     {"X-Grvt-Account-Id": self._cookie["X-Grvt-Account-Id"]}
                 )
+            self._set_trading_account_id_from_cookie()
             self.logger.info(
                 f"update_session_with_cookie {self._cookie=} {self._session.cookie_jar=}"
                 f" {self._session.headers=}"

--- a/src/pysdk/grvt_ccxt_utils.py
+++ b/src/pysdk/grvt_ccxt_utils.py
@@ -108,13 +108,17 @@ def get_cookie_with_expiration(
                     "%a, %d %b %Y %H:%M:%S %Z",
                 )
                 grvt_account_id: str = return_value.headers.get("X-Grvt-Account-Id", "")
+                resp_body = return_value.json() if return_value.text else {}
+                trading_account_id: str = resp_body.get("trading_account_id", "")
                 logging.info(
-                    f"{FN} OK response {cookie_value=} {cookie_expiry=} {grvt_account_id=}"
+                    f"{FN} OK response {cookie_value=} {cookie_expiry=}"
+                    f" {grvt_account_id=} {trading_account_id=}"
                 )
                 return {
                     "gravity": cookie_value,
                     "expires": cookie_expiry.timestamp(),
                     "X-Grvt-Account-Id": grvt_account_id,
+                    "trading_account_id": trading_account_id,
                 }
             logging.warning(f"{FN} Invalid return_value {data=} {path=} {return_value=}")
             return None
@@ -150,13 +154,17 @@ async def get_cookie_with_expiration_async(
                             "%a, %d %b %Y %H:%M:%S %Z",
                         )
                         grvt_account_id: str = return_value.headers.get("X-Grvt-Account-Id", "")
+                        resp_body = await return_value.json() if return_value.content_length else {}
+                        trading_account_id: str = resp_body.get("trading_account_id", "") if isinstance(resp_body, dict) else ""
                         logging.info(
-                            f"{FN} OK response {cookie_value=} {cookie_expiry=} {grvt_account_id=}"
+                            f"{FN} OK response {cookie_value=} {cookie_expiry=}"
+                            f" {grvt_account_id=} {trading_account_id=}"
                         )
                         return {
                             "gravity": cookie_value,
                             "expires": cookie_expiry.timestamp(),
                             "X-Grvt-Account-Id": grvt_account_id,
+                            "trading_account_id": trading_account_id,
                         }
         except Exception as e:
             logging.error(f"{FN} Error getting cookie: {e}")

--- a/src/pysdk/grvt_raw_base.py
+++ b/src/pysdk/grvt_raw_base.py
@@ -36,6 +36,7 @@ class GrvtCookie:
     gravity: str
     expires: datetime
     grvt_account_id: str | None = None
+    trading_account_id: str | None = None
 
 
 class GrvtRawBase:
@@ -98,6 +99,9 @@ class GrvtRawSyncBase(GrvtRawBase):
                 self._session.headers.update(
                     {"X-Grvt-Account-Id": self._cookie.grvt_account_id}
                 )
+            if not self.config.trading_account_id and self._cookie.trading_account_id:
+                self.config.trading_account_id = self._cookie.trading_account_id
+                self.logger.info(f"trading_account_id set from login: {self._cookie.trading_account_id}")
         return None
 
     def _get_cookie(self, path: str, api_key: str) -> GrvtCookie | None:
@@ -127,10 +131,13 @@ class GrvtRawSyncBase(GrvtRawBase):
                 grvt_account_id: str | None = return_value.headers.get(
                     "X-Grvt-Account-Id"
                 )
+                resp_body = return_value.json() if return_value.text else {}
+                trading_account_id: str | None = resp_body.get("trading_account_id")
                 return GrvtCookie(
                     gravity=cookie_value,
                     expires=cookie_expiry,
                     grvt_account_id=grvt_account_id,
+                    trading_account_id=trading_account_id,
                 )
             return None
         except Exception as e:
@@ -192,6 +199,9 @@ class GrvtRawAsyncBase(GrvtRawBase):
                 self._session.headers.update(
                     {"X-Grvt-Account-Id": self._cookie.grvt_account_id}
                 )
+            if not self.config.trading_account_id and self._cookie.trading_account_id:
+                self.config.trading_account_id = self._cookie.trading_account_id
+                self.logger.info(f"trading_account_id set from login: {self._cookie.trading_account_id}")
         return None
 
     async def _get_cookie(self, path: str, api_key: str) -> GrvtCookie | None:
@@ -219,10 +229,13 @@ class GrvtRawAsyncBase(GrvtRawBase):
                         grvt_account_id: str | None = return_value.headers.get(
                             "X-Grvt-Account-Id"
                         )
+                        resp_body = await return_value.json() if return_value.content_length else {}
+                        trading_account_id: str | None = resp_body.get("trading_account_id") if isinstance(resp_body, dict) else None
                         return GrvtCookie(
                             gravity=cookie_value,
                             expires=cookie_expiry,
                             grvt_account_id=grvt_account_id,
+                            trading_account_id=trading_account_id,
                         )
             return None
         except Exception as e:

--- a/tests/pysdk/test_grvt_ccxt.py
+++ b/tests/pysdk/test_grvt_ccxt.py
@@ -271,7 +271,6 @@ def print_description(api: GrvtCcxt):
 def test_grvt_ccxt():
     params = {
         "api_key": os.getenv("GRVT_API_KEY"),
-        "trading_account_id": os.getenv("GRVT_TRADING_ACCOUNT_ID"),
         "private_key": os.getenv("GRVT_PRIVATE_KEY"),
     }
     env = GrvtEnv(os.getenv("GRVT_ENV", "testnet"))

--- a/tests/pysdk/test_grvt_ccxt_pro.py
+++ b/tests/pysdk/test_grvt_ccxt_pro.py
@@ -250,7 +250,6 @@ async def print_description(api: GrvtCcxtPro):
 async def grvt_ccxt_pro():
     params = {
         "api_key": os.getenv("GRVT_API_KEY"),
-        "trading_account_id": os.getenv("GRVT_TRADING_ACCOUNT_ID"),
         "private_key": os.getenv("GRVT_PRIVATE_KEY"),
     }
     env = GrvtEnv(os.getenv("GRVT_ENV", "testnet"))

--- a/tests/pysdk/test_grvt_ccxt_vault.py
+++ b/tests/pysdk/test_grvt_ccxt_vault.py
@@ -33,7 +33,6 @@ def call_vault_redemption_queue(api: GrvtCcxt):
 def test_grvt_ccxt_vault():
     params = {
         "api_key": os.getenv("GRVT_API_KEY"),
-        "trading_account_id": os.getenv("GRVT_TRADING_ACCOUNT_ID"),
         "private_key": os.getenv("GRVT_PRIVATE_KEY"),
     }
     env = GrvtEnv(os.getenv("GRVT_ENV", "testnet"))

--- a/tests/pysdk/test_grvt_ccxt_vault_pro.py
+++ b/tests/pysdk/test_grvt_ccxt_vault_pro.py
@@ -34,7 +34,6 @@ async def call_vault_redemption_queue(api: GrvtCcxtPro):
 async def grvt_ccxt_vault_pro():
     params = {
         "api_key": os.getenv("GRVT_API_KEY"),
-        "trading_account_id": os.getenv("GRVT_TRADING_ACCOUNT_ID"),
         "private_key": os.getenv("GRVT_PRIVATE_KEY"),
     }
     env = GrvtEnv(os.getenv("GRVT_ENV", "testnet"))

--- a/tests/pysdk/test_grvt_ccxt_ws.py
+++ b/tests/pysdk/test_grvt_ccxt_ws.py
@@ -34,7 +34,6 @@ async def subscribe(loop) -> GrvtCcxtWS:
     """Subscribe to Websocket channels and feeds."""
     params = {
         "api_key": os.getenv("GRVT_API_KEY"),
-        "trading_account_id": os.getenv("GRVT_TRADING_ACCOUNT_ID"),
         "api_ws_version": os.getenv("GRVT_WS_STREAM_VERSION", "v1"),
     }
     if os.getenv("GRVT_PRIVATE_KEY"):


### PR DESCRIPTION
## Summary
- Parse `trading_account_id` from `/auth/api_key/login` response body in all login flows (CCXT sync/async, Raw sync/async)
- Auto-set `trading_account_id` when not explicitly provided by the user, removing the need to export `GRVT_TRADING_ACCOUNT_ID`
- Remove `GRVT_TRADING_ACCOUNT_ID` from env config docs and all test files

## Test plan
- [ ] Verify login response includes `trading_account_id` on testnet
- [ ] Verify `GrvtCcxt` auto-populates `trading_account_id` after login without env var
- [ ] Verify `GrvtCcxtPro` / `GrvtCcxtWS` auto-populates `trading_account_id` after login
- [ ] Verify explicitly passing `trading_account_id` in params still takes precedence
- [ ] Run existing test suite with `GRVT_TRADING_ACCOUNT_ID` unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)