### PR TITLE
Fix incorrect limit handling

### DIFF
--- a/src/pysdk/grvt_ccxt_base.py
+++ b/src/pysdk/grvt_ccxt_base.py
@@ -318,7 +318,7 @@ class GrvtCcxtBase:
                 payload["start_time"] = str(start_time)
             if end_time:
                 payload["end_time"] = str(end_time)
-            payload["limit"] = limit | 500
+            payload["limit"] = limit or 500
         return payload
 
     def _get_payload_fetch_positions(self, symbols: list[str] = [], params={}) -> dict:


### PR DESCRIPTION
Changed limit fallback logic in `_get_payload_fetch_account_history`.

The previous implementation used the bitwise OR operator:

`payload["limit"] = limit | 500`

This caused incorrect values because `|` performs a bitwise operation instead of a logical fallback. For example, `limit=1` resulted in `501` instead of `1`.

Replaced it with logical OR:

`payload["limit"] = limit or 500`

Now the payload uses the provided limit value when it is set, and falls back to 500 only when limit is falsy.