### PR TITLE
Remove redundant return_text initialization

### DIFF
--- a/src/pysdk/grvt_ccxt_pro.py
+++ b/src/pysdk/grvt_ccxt_pro.py
@@ -116,7 +116,6 @@ class GrvtCcxtPro(GrvtCcxtBase):
             headers={"Content-Type": "application/json"},
             timeout=5,
         ) as return_value:
-            return_text: str = ""
             try:
                 return_text = await return_value.text()
                 response = await return_value.json(content_type="application/json")


### PR DESCRIPTION
Removed duplicate `return_text` initialization inside `_auth_and_post`.

The variable was already initialized before the request block, so the second declaration was unnecessary and did not change the behavior.